### PR TITLE
Fixed undo and some minor improvements

### DIFF
--- a/Assets/SplineMesh/Scripts/Bezier/Spline.cs
+++ b/Assets/SplineMesh/Scripts/Bezier/Spline.cs
@@ -14,6 +14,7 @@ namespace SplineMesh {
     /// </summary>
     [DisallowMultipleComponent]
     [ExecuteInEditMode]
+    [SelectionBaseAttribute]
     public class Spline : MonoBehaviour {
         /// <summary>
         /// The spline nodes.

--- a/Assets/SplineMesh/Scripts/Bezier/Spline.cs
+++ b/Assets/SplineMesh/Scripts/Bezier/Spline.cs
@@ -16,6 +16,14 @@ namespace SplineMesh {
     [ExecuteInEditMode]
     [SelectionBaseAttribute]
     public class Spline : MonoBehaviour {
+#if UNITY_EDITOR
+        /// <summary>
+        /// Used by SplineEditor to know which node was last selected for this Spline.
+        /// Editor only (not included in runtime).
+        /// </summary>
+        [HideInInspector]
+        public int selectedNodeIndex;
+#endif
         /// <summary>
         /// The spline nodes.
         /// Warning, this collection shouldn't be changed manualy. Use specific methods to add and remove nodes.

--- a/Assets/SplineMesh/Scripts/MeshProcessing/SplineExtrusion.cs
+++ b/Assets/SplineMesh/Scripts/MeshProcessing/SplineExtrusion.cs
@@ -24,6 +24,14 @@ namespace SplineMesh {
     [ExecuteInEditMode]
     [RequireComponent(typeof(Spline))]
     public class SplineExtrusion : MonoBehaviour {
+#if UNITY_EDITOR
+        /// <summary>
+        /// Used by SplineExtrusionEditor to know which vertex was last selected for this SplineExtrusion.
+        /// Editor only (not included in runtime).
+        /// </summary>
+        [HideInInspector]
+        public int selectedVertexIndex;
+#endif
         private Spline spline;
         private bool toUpdate = true;
         private GameObject generated;


### PR DESCRIPTION
1. Fixed undo for Spline and SplineExtrusion. [Sample gif here](https://i.imgur.com/RDNsbiG.gif) (The gif shows an Undo History window because that's in Unity 2021.3, but that isn't required. The changes were applied to Unity 2021.1, the project version specified in the repo).
2. Each Spline will now remember which of its nodes was last selected, so if you reselect that Spline, the last selected node will show up as selected. Same applies for the vertices of SplineExtrusion.
3. Selecting an Extrusion Segment will now select the Spline instead. Clicking again will allow you to select the Extrusion Segment directly. Clicking repeatedly will alternate between selecting the Extrusion Segment and the Spline.

Note: Tried my best to follow the coding style in there, but feel free to change it.